### PR TITLE
[DRAFT PR] +4-5% decompression speed from pipelining litLen / matchLen

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1997,12 +1997,6 @@ LZ4_decompress_generic(
         /* Fast loop : decode sequences as long as output < oend-FASTLOOP_SAFE_DISTANCE */
         token = *ip++;
         litLen = token >> ML_BITS;
-        if (litLen == RUN_MASK) {
-            size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-            if (addl == rvl_error) { goto _output_error; }
-            litLen += addl;
-        }
-
         while (1) {
             /* Main fastloop assertion: We can always wildcopy FASTLOOP_SAFE_DISTANCE */
             assert(oend - op >= FASTLOOP_SAFE_DISTANCE);
@@ -2010,10 +2004,14 @@ LZ4_decompress_generic(
 
             matchLen = token & ML_MASK;
 
-            LZ4_memcpy(op, ip, 16);
-            if (unlikely(litLen > 16)) {
+            /* decode literal length */
+            if (litLen == RUN_MASK) {
+                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (addl == rvl_error) { goto _output_error; }
+                litLen += addl;
                 if (unlikely((uptrval)(op)+litLen<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+litLen<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+
                 /* copy literals */
                 cpy = op+litLen;
                 LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
@@ -2021,9 +2019,20 @@ LZ4_decompress_generic(
                     length = litLen;
                     goto safe_literal_copy;
                 }
-                LZ4_wildCopy32(op+16, ip+16, cpy);
+                LZ4_wildCopy32(op, ip, cpy);
+                ip += litLen; op = cpy;
+            } else {
+                cpy = op+litLen;
+                DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)litLen);
+                /* We don't need to check oend, since we check it once for each loop below */
+                if (ip > iend-(16 + 1/*max lit + offset + nextToken*/)) {
+                    length = litLen;
+                    goto safe_literal_copy;
+                }
+                /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */
+                LZ4_memcpy(op, ip, 16);
+                ip += litLen; op = cpy;
             }
-            ip += litLen; op += litLen;
 
             /* get offset */
             offset = LZ4_readLE16(ip); ip+=2;
@@ -2046,12 +2055,7 @@ LZ4_decompress_generic(
 
                 token = *ip++;
                 litLen = token >> ML_BITS;  /* literal length */
-                if (litLen == RUN_MASK) {
-                    size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                    if (addl == rvl_error) { goto _output_error; }
-                    litLen += addl;
-                }
-           } else {
+            } else {
                 matchLen += MINMATCH;
 
                 if (op + matchLen >= oend - FASTLOOP_SAFE_DISTANCE) {
@@ -2061,11 +2065,6 @@ LZ4_decompress_generic(
 
                 token = *ip++;
                 litLen = token >> ML_BITS;  /* literal length */
-                if (litLen == RUN_MASK) {
-                    size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                    if (addl == rvl_error) { goto _output_error; }
-                    litLen += addl;
-                }
 
                 /* Fastpath check: skip LZ4_wildCopy32 when true */
                 if ((dict == withPrefix64k) || (match >= lowPrefix)) {

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2021,7 +2021,7 @@ LZ4_decompress_generic(
                 }
                 LZ4_wildCopy32(op, ip, cpy);
                 ip += litLen; op = cpy;
-            } else {
+            } else if (litLen > 0) {
                 cpy = op+litLen;
                 DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)litLen);
                 /* We don't need to check oend, since we check it once for each loop below */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2021,7 +2021,7 @@ LZ4_decompress_generic(
                 }
                 LZ4_wildCopy32(op, ip, cpy);
                 ip += litLen; op = cpy;
-            } else if (litLen > 0) {
+            } else {
                 cpy = op+litLen;
                 DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)litLen);
                 /* We don't need to check oend, since we check it once for each loop below */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1997,12 +1997,6 @@ LZ4_decompress_generic(
         /* Fast loop : decode sequences as long as output < oend-FASTLOOP_SAFE_DISTANCE */
         token = *ip++;
         litLen = token >> ML_BITS;
-        if (litLen == RUN_MASK) {
-            size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-            if (addl == rvl_error) { goto _output_error; }
-            litLen += addl;
-        }
-
         while (1) {
             /* Main fastloop assertion: We can always wildcopy FASTLOOP_SAFE_DISTANCE */
             assert(oend - op >= FASTLOOP_SAFE_DISTANCE);
@@ -2011,7 +2005,10 @@ LZ4_decompress_generic(
             matchLen = token & ML_MASK;
 
             /* decode literal length */
-            if (litLen > 16) {
+            if (litLen == RUN_MASK) {
+                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (addl == rvl_error) { goto _output_error; }
+                litLen += addl;
                 if (unlikely((uptrval)(op)+litLen<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+litLen<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
 
@@ -2058,12 +2055,7 @@ LZ4_decompress_generic(
 
                 token = *ip++;
                 litLen = token >> ML_BITS;  /* literal length */
-                if (litLen == RUN_MASK) {
-                    size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                    if (addl == rvl_error) { goto _output_error; }
-                    litLen += addl;
-                }
-           } else {
+            } else {
                 matchLen += MINMATCH;
 
                 if (op + matchLen >= oend - FASTLOOP_SAFE_DISTANCE) {
@@ -2073,11 +2065,6 @@ LZ4_decompress_generic(
 
                 token = *ip++;
                 litLen = token >> ML_BITS;  /* literal length */
-                if (litLen == RUN_MASK) {
-                    size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                    if (addl == rvl_error) { goto _output_error; }
-                    litLen += addl;
-                }
 
                 /* Fastpath check: skip LZ4_wildCopy32 when true */
                 if ((dict == withPrefix64k) || (match >= lowPrefix)) {


### PR DESCRIPTION
Bench environment: clang15 with 32-byte alignment, devserver in bench mode, `bench run -- lz4 -b1 silesia.tar`

**Clang15 (with 32-byte block alignment):**
These numbers are for `-march=haswell -mtune=skylake -mllvm -align-all-blocks=5`. % differences in speeds are similar for just `-march=haswell -mtune=skylake`, although absolute speeds there are higher (closer to gcc11).

dev: 1537.2 MB/s
**65ee747: 1624.3 MB/s** (commit title should read "decompression speed", not "compression speed")
7bdacea: 1152.9 MB/s 
94e1ef6: 1595 MB/s (half the win, but only 5 lines of code!)

**Gcc11 (no block alignment):**
These numbers are for `-march=haswell -mtune=skylake`.

dev: 1676.5 MB/s 
**65ee747: 1736.7 MB/s**